### PR TITLE
Add min, max & unit to ProcessParameter

### DIFF
--- a/src/main/kotlin/brewprocess/ProcessParameter.kt
+++ b/src/main/kotlin/brewprocess/ProcessParameter.kt
@@ -12,6 +12,9 @@ data class ProcessParameter<T>(
     val type: ProcessParameterType = ProcessParameterType.INT,
     val prompt: String,
     val description: String?,
+    val unit: String? = null,
     val setter: (T) -> Boolean,
-    val current: T?
+    val current: T?,
+    val min: T? = null,
+    val max: T? = null
 )

--- a/src/main/kotlin/brewprocess/Task.kt
+++ b/src/main/kotlin/brewprocess/Task.kt
@@ -71,7 +71,7 @@ sealed class Task(val name: String, var order: Int? = null) {
         return this.dependentTasks.mapNotNull { parameterForDependantTask(it) }
     }
 
-    private fun parameterForDependantTask(dependantTask: DependentTask): ProcessParameter<*>? {
+    private fun parameterForDependantTask(dependantTask: DependentTask): ProcessParameter<*> {
         val name: String
         val prompt: String
         val description: String? = null
@@ -106,8 +106,10 @@ sealed class Task(val name: String, var order: Int? = null) {
             name = name,
             prompt = prompt,
             description = description,
+            unit = "mn",
             setter = dependantTask::setDelayInMin,
-            current = dependantTask.delayInMin
+            current = dependantTask.delayInMin,
+            min = 0
         )
     }
 }
@@ -134,8 +136,10 @@ class Boil(
                     "When heating 'l' litters of water from 'T1'° to 'T2'° in 't' seconds, the actual heating power " +
                     "is calculated as:\n  (4185 x (T2 - T1) x l) / t.\n" +
                     "Must be greater than 0 (no decimals).",
+                unit = "w",
                 setter = this::setHeatingPower,
-                current = this.heatingPower
+                current = this.heatingPower,
+                min = 0
             )
         )
 
@@ -163,8 +167,10 @@ class Lauter(
                 description = "This will allow to calculate the time you need to lauter your mash.\n" +
                     "It will be derived from the water throughput expressed as liters per minute.\n" +
                     "Must be greater than 0 (decimals allowed).",
+                unit = "l / h",
                 setter = this::setLitersPerMin,
-                current = this.litersPerMin
+                current = this.litersPerMin,
+                min = 0.0
             )
         )
 
@@ -192,8 +198,10 @@ class DrainMash(
                 description = "When using BIAB or other single vessel process, this will define the time you will " +
                     "time it takes to drain the mash before the boil stage.\n" +
                     "Must be greater than 0 (in minutes, no decimals).",
+                unit = "mn",
                 setter = this::setDuration,
-                current = this.duration
+                current = this.duration,
+                min = 0
             )
         )
 
@@ -230,8 +238,10 @@ class HeatWater(
                     "When heating 'l' litters of water from 'T1'° to 'T2'° in 't' seconds, the actual heating power " +
                     "is calculated as:\n  (4185 x (T2 - T1) x l) / t.\n" +
                     "Must be greater than 0 (no decimals).",
+                unit = "w",
                 setter = this::setHeatingPower,
-                current = this.heatingPower
+                current = this.heatingPower,
+                min = 0
             )
         )
 
@@ -260,8 +270,10 @@ class Chill(
                     "When cooling 'l' litters of water from 'T1'° down to 'T2'° in 't' seconds, the cooling capability is calculated as:\n" +
                     "  (4185 x (T2 - T1) x l) / t.\n" +
                     "Must be greater than 0 (no decimals).",
+                unit = "w",
                 setter = this::setChillingPower,
-                current = this.chillingPower
+                current = this.chillingPower,
+                min = 0
             )
         )
 

--- a/src/main/kotlin/command/config/ConfigCommand.kt
+++ b/src/main/kotlin/command/config/ConfigCommand.kt
@@ -76,7 +76,8 @@ class ConfigCommand(bdsDirectory: File) : Callable<Int> {
                         help = parameter.description,
                         default = parameter.current as Int,
                         valueType = Int::class,
-                        min = 0 // TODO: Should rather be an attribute of the ProcessParameter
+                        min = parameter.min,
+                        max = parameter.max
                     ).prompt()
 
                     if (newValue != null) {
@@ -92,7 +93,8 @@ class ConfigCommand(bdsDirectory: File) : Callable<Int> {
                         help = parameter.description,
                         default = parameter.current as Double,
                         valueType = Double::class,
-                        min = 0.0 // TODO: Should rather be an attribute of the ProcessParameter
+                        min = parameter.min,
+                        max = parameter.max
                     ).prompt()
 
                     if (newValue != null) {

--- a/src/main/kotlin/command/prompt/Prompt.kt
+++ b/src/main/kotlin/command/prompt/Prompt.kt
@@ -49,8 +49,8 @@ class Prompt<T : Comparable<T>>(
                 continue
             }
 
-            val valueIsBelowMin = min != null && value < min
-            val valueIsAboveMax = max != null && value > max
+            val valueIsBelowMin = (min != null) && (value < min)
+            val valueIsAboveMax = (max != null) && (value > max)
             if (valueIsBelowMin || valueIsAboveMax) {
                 println(buildOutOfBoundariesMessage(input))
                 value = null
@@ -107,7 +107,7 @@ class Prompt<T : Comparable<T>>(
                 when {
                     listOf("y", "yes", "true").contains(input.lowercase()) -> return true as T
                     listOf("n", "no", "false").contains(input.lowercase()) -> return false as T
-                    else -> null
+                    else -> return null
                 }
             }
         }

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -4,8 +4,8 @@ class TestHelper {
     companion object {
         private const val TEST_EMPTY_DIRECTORY_NAME = "test_empty_directory"
         private const val TEST_HOME_DIRECTORY_NAME = "test_home_directory"
-        val TEST_EMPTY_DIRECTORY = File(this.javaClass.classLoader.getResource(TEST_EMPTY_DIRECTORY_NAME).file)
-        val TEST_HOME_DIRECTORY = File(this.javaClass.classLoader.getResource(TEST_HOME_DIRECTORY_NAME).file)
+        val TEST_EMPTY_DIRECTORY = File(this::class.java.classLoader.getResource(TEST_EMPTY_DIRECTORY_NAME)!!.file)
+        val TEST_HOME_DIRECTORY = File(this::class.java.classLoader.getResource(TEST_HOME_DIRECTORY_NAME)!!.file)
         val TEST_BDS_DIRECTORY = File(TEST_HOME_DIRECTORY, AppConstants.APP_DIRECTORY)
 
         fun resetTestEmptyDirectory() {


### PR DESCRIPTION
`min` is necessary to fully configure the Prompt.
`unit` is necessary to list the configuration.
`max` is provisional.

**Note**: no tests are included here as it is mostly getters and setters (`Prompt` is fully tested and we know it deals with `min`). 